### PR TITLE
removed flag to resolve compile error

### DIFF
--- a/Software/GameEngine/common.make
+++ b/Software/GameEngine/common.make
@@ -65,7 +65,6 @@ CFLAGS += -DDC801_EMBEDDED --short-enums
 
 # C++ flags common to all targets
 CXXFLAGS = -felide-constructors \
-	-fno-exceptions \
 	-fno-rtti \
 	-Wno-register
 else


### PR DESCRIPTION
Removing this flag resolves the following compile error.

```
~/dev/BM-Badge/Software/GameEngine/src/games/mage/mage_command_control.cpp: In member function 'void MageCommandControl::processCommandAsResponseInput(std::string)':
~/dev/BM-Badge/Software/GameEngine/src/games/mage/mage_command_control.cpp:192:27: error: exception handling disabled, use '-fexceptions' to enable
  192 |   } catch(std::exception &err) {
      |                           ^~~
make: *** [common.make:165: ~/dev/BM-Badge/Software/GameEngine/build/games/mage/mage_command_control.o] Error 1
```