### PR TITLE
Add scuba build and instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,54 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Setup for Desktop builds
+# GDB from EnvironmentSetup.md is omitted
+# because it should be installed on the host instead
+RUN apt-get update && \
+  apt-get install -y \
+  build-essential \
+  make \
+  git \
+  git-gui \
+  gitk \
+  wget \
+  libsdl2-2.0-0 \
+  libsdl2-image-2.0-0 \
+  libsdl2-dev \
+  libsdl2-image-dev \
+  libncurses5 \
+  libncurses-dev \
+  python3-pip \
+  coreutils \
+  zip \
+  unzip \
+  && pip3 install compiledb
+
+ENV HOME="/home/dc801"
+
+RUN mkdir -p ~/dev/installer && \
+  echo 'PATH="$HOME/.local/bin:$PATH"' >>~/.profile \
+  && echo 'export PATH="$HOME/.local/bin:$PATH"' >>~/.bash_profile
+ 
+
+# Setup for Embedded builds
+WORKDIR "${HOME}/dev/installer"
+
+RUN wget https://armkeil.blob.core.windows.net/developer/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2 && \
+  export EABI_VERSION=10-2020-q4-major && \
+  tar xjf gcc-arm-none-eabi-$EABI_VERSION-x86_64-linux.tar.bz2 -C /usr/share && \
+  ln -s /usr/share/gcc-arm-none-eabi-$EABI_VERSION/bin/arm-none-eabi-* /usr/bin
+
+RUN wget http://developer.nordicsemi.com/nRF5_SDK/nRF5_SDK_v15.x.x/nRF5_SDK_15.3.0_59ac345.zip && \
+  unzip nRF5_SDK_15.3.0_59ac345.zip && \
+  mv nRF5_SDK_*/ ~/dev/nordic-sdk15.3.0
+
+RUN printf "GNU_INSTALL_ROOT ?= /usr/bin/\nGNU_VERSION ?= 10.2.1\nGNU_PREFIX ?= arm-none-eabi\n" \
+  >~/dev/nordic-sdk15.3.0/components/toolchain/gcc/Makefile.posix
+
+RUN wget https://www.nordicsemi.com/-/media/Software-and-other-downloads/Desktop-software/nRF-command-line-tools/sw/Versions-10-x-x/10-12-2/nRF-Command-Line-Tools_10_12_2_Linux-amd64.zip && \
+  unzip nRF-Command-Line-Tools_10_12_2_Linux-amd64.zip && \
+  cd nRF-Command-Line-Tools_10_12_2_Linux-amd64 && \
+  tar -xvf nRF-Command-Line-Tools_10_12_2_Linux-amd64.tar.gz && \
+  dpkg -i *.deb
+

--- a/EnvironmentSetup.md
+++ b/EnvironmentSetup.md
@@ -10,6 +10,49 @@ This guide is written assuming you will be using Ubuntu 20.04 or greater. It wil
 
 ----
 
+## NEW: Docker Build
+
+You can now build an Ubuntu image with Docker and use scuba to build the project.
+
+First, install docker on your local machine. Unfortunately, this is very distro-dependent. Here's the [instructions for Ubuntu](https://docs.docker.com/engine/install/ubuntu/) at least.
+
+There's also some helpful [postinstall steps](https://docs.docker.com/engine/install/linux-postinstall/). You should at least add yourself to the docker group. The others are normally done for you or are non-essential.
+
+To build the project using Docker, you must build the image using the dockerfile in BM-Badge. That can be done like this.
+
+```sh
+~/dev/BM-Badge $ docker build -t bm-badge .
+```
+
+After that, install scuba on your machine as well by following these [installation steps](https://scuba.readthedocs.io/en/latest/installation.html).
+
+```sh
+sudo pip install scuba
+```
+
+Then, you can execute the following commands after navigating to Software/GameEngine in the BM-Badge repo
+
+```sh
+# Do a desktop build
+~/dev/BM-Badge/Software/GameEngine $ scuba desktop
+
+# Do an embedded build
+~/dev/BM-Badge/Software/GameEngine $ scuba embedded
+
+# Clean the current project
+~/dev/BM-Badge/Software/GameEngine $ scuba clean
+~/dev/BM-Badge/Software/GameEngine $ scuba cleanall
+
+# Flash the embedded build to the hardware
+~/dev/BM-Badge/Software/GameEngine $ scuba flash
+
+# Use GDBServer to debug on hardware
+~/dev/BM-Badge/Software/GameEngine $ scuba gdbserver
+
+# Use JLink to debug on hardware
+~/dev/BM-Badge/Software/GameEgnine $ scuba jlink
+```
+
 ## Desktop Build
 Since __**THE HARDWARE ISN'T READY YET**__, you early adopters will have to try out our game on your computer that runs about a thousand times faster than our real badge hardware - so if it seems like it runs a little faster than it should, uhh... get used to it.
 
@@ -225,7 +268,7 @@ mv nRF5_SDK_*/ ../nordic-sdk15.3.0/
 
 Now you need to configure the SDK for the GCC compiler
 
-Edit the file `~/dev/nordic-sdk15.3.0/components/toolchain/gcc/Makefike.posix`
+Edit the file `~/dev/nordic-sdk15.3.0/components/toolchain/gcc/Makefile.posix`
 
 It should read:
 ```shell script

--- a/Software/GameEngine/.scuba.yml
+++ b/Software/GameEngine/.scuba.yml
@@ -1,0 +1,19 @@
+image: bm-badge:latest
+
+aliases:
+        desktop: cd $SCUBA_ROOT && compiledb make DESKTOP=1 -j`nproc`
+        embedded: cd $SCUBA_ROOT && compiledb make EMBEDDED=1 -j`nproc`
+        clean: cd $SCUBA_ROOT && make cleanall -j`nproc`
+        cleanall: cd $SCUBA_ROOT && make cleanall -j`nproc`
+        flash:
+                docker_args: --privileged -v /dev:/dev
+                script:
+                        - cd $SCUBA_ROOT && compiledb make flash EMBEDDED=1 -j`nproc`
+        gdbserver:
+                docker_args: --privileged -v /dev:/dev -p 2331:2331
+                script:
+                        - JLinkGDBServer -device nrf52 -if SWD -speed 4000
+        jlink:
+                docker_args: --privileged -v /dev:/dev
+                script:
+                        - JLinkExe -device nrf52 -if SWD -speed 4000 -autoconnect 1


### PR DESCRIPTION
Add scuba build as an alternative to using virtual machines like we've done previously.

Some advantages are decreased download sizes, easier sharing between host and guest environments, and less overall virtualization.

Scuba can also run JLink or gdbserver on the device. GDBServer can be connected to using [VSCode](https://stackoverflow.com/questions/53519668/how-to-attach-to-remote-gdb-with-vscode) but I'm unsure how to make it connect to JLink. That may be a future commit.